### PR TITLE
Fix v86 compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "crates/wasi",
+    "crates/v86",
     "crates/v86-lib",
     "crates/tuntap",
 ]


### PR DESCRIPTION
## Changelog

Fixes the following error when running `make`:

```
mkdir -p target/
BLOCK_SIZE=K ls -l target/v86-debug.wasm
-rwxr-xr-x  1 z  staff  14037846 18 Jul 13:51 target/v86-debug.wasm
cd  crates/v86 && CARGO_TARGET_PATH=../../target cargo rustc --target wasm32-unknown-unknown -- -C linker="tools/rust-lld-wrapper" -C link-args="--import-table --global-base=4096 " -C link-args="target/softfloat.o" -C link-args="target/zstddeclib.o" --verbose -C target-feature=+bulk-memory   -C overflow-checks=off 
error: current package believes it's in a workspace when it's not:
current:   [redacted]/blocklessnetwork/v86-wasi/crates/v86/Cargo.toml
workspace: [redacted]/blocklessnetwork/v86-wasi/Cargo.toml

this may be fixable by adding `crates/v86` to the `workspace.members` array of the manifest located at: [redacted]/blocklessnetwork/v86-wasi/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
make: *** [target/v86-debug.wasm] Error 101
```